### PR TITLE
Fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,9 @@ license = "MIT"
 repository = "https://github.com/bmmtstb/manim-meshes"
 
 [tool.poetry.dependencies]
-python = "3.8.18"
+python = "^3.8.18"
 decorator = "^5.0.9"
 manim = "^0.16.0"
-manimgl = "^1.6.1"
-ManimPango = "^0.4.1"
 numpy = "^1.24.0"
 trimesh = "^3.12.5"
 moderngl = "*"
@@ -29,4 +27,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.plugins."manim.plugins"]
-"manim_meshes" = "module:object.attr"
+"manim_meshes" = "manim_meshes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/bmmtstb/manim-meshes"
 
 [tool.poetry.dependencies]
 python = "^3.8.18"
-decorator = "^5.0.9"
-manim = "^0.16.0"
-numpy = "^1.24.0"
+decorator = ">=5.0.9"
+manim = ">=0.16.0"   
+numpy = ">=1.24.0"
 trimesh = "^3.12.5"
 moderngl = "*"
 
@@ -21,6 +21,8 @@ meshio = "^5.3.4"
 pylint = "3.0.2"
 pytest = "^7.2.0"
 typing = "^3.7"
+ManimPango = "^0.4.1"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/manim_meshes/params.py
+++ b/src/manim_meshes/params.py
@@ -6,6 +6,7 @@ from typing import Any
 # third-party imports
 from colour import Color
 import manim as m
+from manim import ManimColor
 import moderngl
 # local imports
 from manim_meshes.exceptions import BadParameterException
@@ -21,11 +22,11 @@ BM3DM: DefaultParameters = {
     "clear_vertices":                             (bool, True),
     "clear_edges":                                (bool, True),
     "clear_faces":                                (bool, True),
-    "edges_color":                                (Color, Color(m.BLUE)),
+    "edges_color":                                (ManimColor, m.BLUE),
     "edges_width":                                (float, 0.1),
-    "faces_color":                                (Color, Color(m.BLUE_D)),
+    "faces_color":                                (ManimColor, m.BLUE_D),
     "faces_opacity":                              (float, 0.4),
-    "verts_color":                                (Color, Color(m.GREEN)),
+    "verts_color":                                (ManimColor, m.GREEN),
     "verts_size":                                 (float, 0.04),
     "pre_function_handle_to_anchor_scale_factor": (float, 0.00001),
 }
@@ -38,18 +39,18 @@ BM2DM: DefaultParameters = {
     "clear_vertices":                             (bool, True),
     "clear_edges":                                (bool, True),
     "clear_faces":                                (bool, True),
-    "edges_color":                                (Color, Color(m.LIGHT_GREY)),
+    "edges_color":                                (ManimColor, m.LIGHT_GREY),
     "edges_width":                                (float, 1.5),
-    "faces_color":                                (Color, Color(m.BLUE_E)),
+    "faces_color":                                (ManimColor, m.BLUE_E),
     "faces_opacity":                              (float, 1.),
-    "verts_color":                                (Color, Color(m.GREEN)),
+    "verts_color":                                (ManimColor, m.GREEN),
     "verts_size":                                 (float, 0.02),
     "pre_function_handle_to_anchor_scale_factor": (float, 0.00001),
 }
 
 # opengl_mesh_default_params
 OGLM: DefaultParameters = {
-    "color": (Color, Color(m.GREY)),
+    "color": (ManimColor, m.GREY),
     "depth_test": (bool, True),
     "gloss": (float, 0.3),
     "opacity": (float, 1.0),


### PR DESCRIPTION
allow other versions of python, move manimpango dependency to dev-dependencies (as it's only used for tests), remove manimgl dependency, changed numpy dependency to >= instead of ^ to support numpy 2.0